### PR TITLE
Making KvDroid standalone (can create android native ui and have its own mainloop runner)

### DIFF
--- a/kvdroid/app.py
+++ b/kvdroid/app.py
@@ -1,9 +1,9 @@
 from kvdroid.event import EventDispatcher
 from kvdroid.base import EventLoop
+from android.runnable import run_on_ui_thread
 from kvdroid import activity
 from kvdroid.jclass.android import RelativeLayout
 from kvdroid.jclass.android import ViewGroupLayoutParams
-from kvdroid import Logger
 
 
 class App(EventDispatcher):
@@ -31,13 +31,16 @@ class App(EventDispatcher):
             None or a root :class:`~android.widget.RelativeLayout` instance
             if no self.root exists."""
         if not self.root:
-            relative_layout = RelativeLayout(activity)
-            layout_params = ViewGroupLayoutParams()
-            activity.addContentView(
-                relative_layout,
-                layout_params(layout_params.MATCH_PARENT, layout_params.FILL_PARENT)
-            )
-            return relative_layout
+            return RelativeLayout(activity)
+
+    @run_on_ui_thread
+    def add_content_view(self, layout):
+        layout_params = ViewGroupLayoutParams()
+        activity.addContentView(
+            layout,
+            layout_params(layout_params.MATCH_PARENT, layout_params.FILL_PARENT)
+        )
+        return layout
 
     def on_create(self):
         """Event handler for the `on_create` event which is fired after
@@ -62,6 +65,7 @@ class App(EventDispatcher):
         if not self.root:
             Logger.critical("Application: No Layout was returned in build")
             return
+        self.add_content_view(self.root)
         self._eventloop.status = "created"
         self.dispatch("on_create")
         self._eventloop.mainloop()

--- a/kvdroid/app.py
+++ b/kvdroid/app.py
@@ -1,0 +1,78 @@
+from kvdroid.event import EventDispatcher
+from kvdroid.base import EventLoop
+from kvdroid import activity
+from kvdroid.jclass.android import RelativeLayout
+from kvdroid.jclass.android import ViewGroupLayoutParams
+from kvdroid import Logger
+
+
+class App(EventDispatcher):
+    # Return the current running App instance
+    _running_app = None
+
+    def __init__(self, **kwargs):
+        App._running_app = self
+        super().__init__(**kwargs)
+        self.register_event_type("on_pause")
+        self.register_event_type("on_create")
+        self.register_event_type("on_destroy")
+        self.register_event_type("on_resume")
+        self._eventloop = EventLoop()
+
+        #: The *root* widget returned by the :meth:`build_view`
+        self.root = None
+
+    def build_view(self):
+        """Initializes the application; it will be called only once.
+        If this method returns a widget (tree), it will be used as the root
+        widget and added to the window.
+
+        :return:
+            None or a root :class:`~android.widget.RelativeLayout` instance
+            if no self.root exists."""
+        if not self.root:
+            relative_layout = RelativeLayout(activity)
+            layout_params = ViewGroupLayoutParams()
+            activity.addContentView(
+                relative_layout,
+                layout_params(layout_params.MATCH_PARENT, layout_params.FILL_PARENT)
+            )
+            return relative_layout
+
+    def on_create(self):
+        """Event handler for the `on_create` event which is fired after
+        initialization (after build() has been called) but before the
+        application has started running.
+        """
+
+    def on_pause(self):
+        """Event handler called when Pause mode is requested"""
+
+    def on_destroy(self):
+        """Event handler for the `on_destroy` event which is fired when the
+        application has finished running (i.e. the window is about to be
+        closed).
+        """
+
+    def on_resume(self):
+        pass
+
+    def run(self):
+        self.root = self.build_view()
+        if not self.root:
+            Logger.critical("Application: No Layout was returned in build")
+            return
+        self._eventloop.status = "created"
+        self.dispatch("on_create")
+        self._eventloop.mainloop()
+
+    @staticmethod
+    def get_running_app():
+        """Return the currently running application instance.
+        """
+        return App._running_app
+
+    def stop(self):
+        self.dispatch("on_destroy")
+        self._eventloop.close()
+        App._running_app = None

--- a/kvdroid/app.py
+++ b/kvdroid/app.py
@@ -4,6 +4,7 @@ from android.runnable import run_on_ui_thread
 from kvdroid import activity
 from kvdroid.jclass.android import RelativeLayout
 from kvdroid.jclass.android import ViewGroupLayoutParams
+from kvdroid import Logger
 
 
 class App(EventDispatcher):

--- a/kvdroid/base.py
+++ b/kvdroid/base.py
@@ -9,7 +9,7 @@ class EventLoop(EventDispatcher):
         self.app = App.get_running_app()
         self.quit = False
         self.status = "idle"
-        self.resume = False
+        self.resumed = False
         self.destroyed = False
         self.paused = False
 
@@ -18,20 +18,20 @@ class EventLoop(EventDispatcher):
             self.poll()
 
     def poll(self):
-        if activity.isResumed() and not self.resume:
+        if activity.isResumed() and not self.resumed:
             self.app.dispatch("on_resume")
-            self.resume = activity.resume
+            self.resumed = activity.resumed
             self.paused = False
 
         if activity.isDestroyed() and not self.destroyed:
             self.app.dispatch("on_destroy")
             self.destroyed = activity.destroyed
-            self.resume = False
+            self.resumed = False
 
         if not activity.hasWindowFocus() and not self.paused:
             self.app.dispatch("on_pause")
             self.paused = True
-            self.resume = False
+            self.resumed = False
 
     def close(self):
         self.quit = True

--- a/kvdroid/base.py
+++ b/kvdroid/base.py
@@ -1,11 +1,11 @@
 from kvdroid.event import EventDispatcher
 from kvdroid import activity
-from kvdroid.app import App
 
 
 class EventLoop(EventDispatcher):
     def __init__(self):
         super(EventLoop, self).__init__()
+        from kvdroid.app import App
         self.app = App.get_running_app()
         self.quit = False
         self.status = "idle"

--- a/kvdroid/base.py
+++ b/kvdroid/base.py
@@ -1,0 +1,40 @@
+from kvdroid.event import EventDispatcher
+from kvdroid import activity
+from kvdroid.app import App
+
+
+class EventLoop(EventDispatcher):
+    def __init__(self):
+        super(EventLoop, self).__init__()
+        self.app = App.get_running_app()
+        self.quit = False
+        self.status = "idle"
+        self.resume = False
+        self.destroyed = False
+        self.paused = False
+
+    def mainloop(self):
+        while not self.quit and self.status == "created":
+            self.poll()
+
+    def poll(self):
+        if activity.isResumed() and not self.resume:
+            self.app.dispatch("on_resume")
+            self.resume = activity.resume
+            self.paused = False
+
+        if activity.isDestroyed() and not self.destroyed:
+            self.app.dispatch("on_destroy")
+            self.destroyed = activity.destroyed
+            self.resume = False
+
+        if not activity.hasWindowFocus() and not self.paused:
+            self.app.dispatch("on_pause")
+            self.paused = True
+            self.resume = False
+
+    def close(self):
+        self.quit = True
+        self.status = "destroyed"
+
+

--- a/kvdroid/cast.py
+++ b/kvdroid/cast.py
@@ -8,7 +8,8 @@ castable_packages = {
     "downloadManager": "android.app.DownloadManager",
     "charSequence": "java.lang.CharSequence",
     "bitmapdrawable": "android.graphics.drawable.BitmapDrawable",
-    "adaptiveicondrawable": "android.graphics.drawable.AdaptiveIconDrawable"
+    "adaptiveicondrawable": "android.graphics.drawable.AdaptiveIconDrawable",
+    "audioManager": "android.media.AudioManager"
 }
 
 

--- a/kvdroid/event.py
+++ b/kvdroid/event.py
@@ -1,0 +1,76 @@
+# Borrowed from the logics and algorithms of kivy framework
+
+
+class EventDispatcher(object):
+    __event_stack = {}
+
+    def register_event_type(self, event_type):
+        """Register an event type with the dispatcher.
+        Registering event types allows the dispatcher to validate event handler
+        names as they are attached and to search attached objects for suitable
+        handlers. Each event type declaration must:
+            1. start with the prefix `on_`.
+            2. have a default handler in the class.
+        """
+
+        if event_type[:3] != 'on_':
+            raise Exception('A new event must start with "on_"')
+
+        # Ensure that the user has at least declared the default handler
+        if not hasattr(self, event_type):
+            raise Exception(
+                f'Missing default handler {event_type} in {self.__class__.__name__}')
+
+        # Add the event type to the stack
+        if event_type not in self.__event_stack:
+            self.__event_stack[event_type] = []
+
+    def unregister_event_type(self, event_type):
+        pass
+
+    def bind(self, **kwargs):
+        for key, value in kwargs.items():
+            assert callable(value), '{!r} is not callable'.format(value)
+            if key[:3] == 'on_':
+                observers: list = self.__event_stack.get(key)
+                if observers is None:
+                    continue
+                observers.append(value)
+
+    def unbind(self, **kwargs):
+        """Unbind event from callback functions with similar usage as"""
+
+        for key, value in kwargs.items():
+            if key[:3] == 'on_':
+                observers: list = self.__event_stack.get(key)
+                if observers is None:
+                    continue
+                observers.remove(value)
+
+    def is_event_type(self, event_type):
+        """Return True if the event_type is already registered.
+        """
+        return event_type in self.__event_stack
+
+    def dispatch(self, event_type, *args, **kwargs):
+        """Dispatch an event across all the handlers added in bind/fbind().
+        As soon as a handler returns True, the dispatching stops.
+        The function collects all the positional and keyword arguments and
+        passes them on to the handlers.
+        .. note::
+           The handlers are called in reverse order than they were registered
+           with :meth:`bind`.
+        :Parameters:
+           `event_type`: str
+               the event name to dispatch.
+        .. versionchanged:: 1.9.0
+           Keyword arguments collection and forwarding was added. Before, only
+           positional arguments would be collected and forwarded.
+        """
+        observers: list = self.__event_stack.get(event_type)
+        observers.reverse()
+        for callbacks in observers:
+            callbacks(*args, **kwargs)
+
+        handler = getattr(self, event_type)
+        return handler(*args, **kwargs)

--- a/kvdroid/jclass/android/view.py
+++ b/kvdroid/jclass/android/view.py
@@ -10,5 +10,9 @@ def WindowManager(*args, instantiate: bool = False):
     return _class_call(autoclass("android.view.WindowManager"), args, instantiate)
 
 
-def LayoutParams(*args, instantiate: bool = False):
+def WindowManagerLayoutParams(*args, instantiate: bool = False):
     return _class_call(autoclass("android.view.WindowManager$LayoutParams"), args, instantiate)
+
+
+def ViewGroupLayoutParams(*args, instantiate: bool = False):
+    return _class_call(autoclass('android.view.ViewGroup$LayoutParams'), args, instantiate)

--- a/kvdroid/jclass/android/widget.py
+++ b/kvdroid/jclass/android/widget.py
@@ -2,5 +2,17 @@ from jnius import autoclass
 from kvdroid.jclass import _class_call
 
 
-def Toast(instantiate: bool=False, *args):
+def Toast(*args, instantiate: bool = False):
     return _class_call(autoclass('android.widget.Toast'), args, instantiate)
+
+
+def RelativeLayout(*args, instantiate: bool = False):
+    return _class_call(autoclass('android.widget.RelativeLayout'), args, instantiate)
+
+
+def LinearLayout(*args, instantiate: bool = False):
+    return _class_call(autoclass('android.widget.LinearLayout'), args, instantiate)
+
+
+def TextView(*args, instantiate: bool = False):
+    return _class_call(autoclass('android.widget.TextView'), args, instantiate)

--- a/kvdroid/tools/__init__.py
+++ b/kvdroid/tools/__init__.py
@@ -1,7 +1,7 @@
 from time import sleep
 from typing import Union
 from kvdroid import _convert_color
-from jnius import JavaException # NOQA
+from jnius import JavaException  # NOQA
 from kvdroid import activity
 from kvdroid.jclass.java import URL
 from kvdroid.jclass.android import (
@@ -15,7 +15,7 @@ from kvdroid.jclass.android import (
     Rect,
     URLUtil
 )
-from android.runnable import run_on_ui_thread # NOQA
+from android.runnable import run_on_ui_thread  # NOQA
 
 
 def toast(message):
@@ -30,7 +30,7 @@ def share_text(text, title='Share', chooser=False, app_package=None, call_playst
     if app_package:
         from kvdroid import packages
         app_package = packages[app_package] if app_package in packages else None
-        from jnius import JavaException # NOQA
+        from jnius import JavaException  # NOQA
         try:
             intent.setPackage(String(app_package))
         except JavaException:
@@ -145,9 +145,9 @@ def change_statusbar_color(color: Union[str, list], text_color):
         window.getDecorView().setSystemUiVisibility(0)
     else:
         raise TypeError("Available options are ['white','black'] for StatusBar text color")
-    from kvdroid.jclass.android import LayoutParams
-    window.clearFlags(LayoutParams().FLAG_TRANSLUCENT_STATUS)
-    window.addFlags(LayoutParams().FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+    from kvdroid.jclass.android import WindowManagerLayoutParams
+    window.clearFlags(WindowManagerLayoutParams().FLAG_TRANSLUCENT_STATUS)
+    window.addFlags(WindowManagerLayoutParams().FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
     window.setStatusBarColor(Color().parseColor(color))
 
 
@@ -191,14 +191,15 @@ def keyboard_height():
     except JavaException:
         return 0
 
+
 @run_on_ui_thread
-def immersive_mode(status = 'enable'):
+def immersive_mode(status='enable'):
     window = activity.getWindow()
     from kvdroid.jclass.android import View
     View = View()
     if status == "disable":
         return window.getDecorView().setSystemUiVisibility(
-                View.SYSTEM_UI_FLAG_LAYOUT_STABLE)
+            View.SYSTEM_UI_FLAG_LAYOUT_STABLE)
     else:
         return window.getDecorView().setSystemUiVisibility(
             View.SYSTEM_UI_FLAG_LAYOUT_STABLE
@@ -207,6 +208,7 @@ def immersive_mode(status = 'enable'):
             | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
             | View.SYSTEM_UI_FLAG_FULLSCREEN
             | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
+
 
 def launch_app_activity(app_package, app_activity):
     intent = Intent(Intent().ACTION_VIEW)

--- a/kvdroid/tools/audio.py
+++ b/kvdroid/tools/audio.py
@@ -1,23 +1,42 @@
 from threading import Thread
 from typing import Callable
-from jnius.jnius import JavaException
+
+from jnius import PythonJavaClass
+from jnius.jnius import JavaException, java_method
 from kvdroid.jclass.android import MediaPlayer, AudioManager
+from kvdroid.cast import cast_object
+from kvdroid import activity
+from kvdroid.jclass.android import Context
 
 
-class Player(object):
-    mPlayer = MediaPlayer(instantiate=True)
-    content = None
+class OnAudioFocusChangeListener(PythonJavaClass):
+    __javainterfaces__ = ["android/media/AudioManager$OnAudioFocusChangeListener"]
+    __javacontext__ = "app"
+
+    def __init__(self, callback, **kwargs):
+        super(OnAudioFocusChangeListener, self).__init__(**kwargs)
+        self.callback = callback
+
+    @java_method("(I)V")
+    def onAudioFocusChange(self, focus_change):
+        self.callback(focus_change)
+
+
+class Player:
+    def __init__(self, on_audio_focus_change: Callable = None):
+        self.on_audio_focus_change = on_audio_focus_change
+        self.mPlayer = None
+        self.content = None
 
     def raw(self):
         return self.mPlayer
 
     def play(self, content: str):
+        if not self.mPlayer:
+            self.mPlayer = MediaPlayer(instantiate=True)
         self.content = content
-        try:
-            self.mPlayer.stop()
-            self.mPlayer.reset()
-        except JavaException:
-            pass
+        self.mPlayer.stop()
+        self.mPlayer.reset()
         self.mPlayer.setDataSource(self.content)
         self.mPlayer.prepare()
         self.mPlayer.start()
@@ -35,23 +54,22 @@ class Player(object):
         Thread(target=self._stream, args=(content, on_load_finish)).start()
 
     def _stream(self, content: str, on_load_finish: Callable):
+        if not self.mPlayer:
+            self.mPlayer = MediaPlayer(instantiate=True)
         try:
-            from kivy.clock import mainthread # NOQA
-            @mainthread # NOQA
+            from kivy.clock import mainthread  # NOQA
+            @mainthread  # NOQA
             def load_finish():
                 on_load_finish()
         except ImportError:
             from android.runnable import run_on_ui_thread  # NOQA
-            @run_on_ui_thread # NOQA
+            @run_on_ui_thread  # NOQA
             def load_finish():
                 on_load_finish()
         self.content = content
         self.mPlayer.setAudioStreamType(AudioManager().STREAM_MUSIC)
-        try:
-            self.mPlayer.stop()
-            self.mPlayer.reset()
-        except JavaException:
-            pass
+        self.mPlayer.stop()
+        self.mPlayer.reset()
         self.mPlayer.setDataSource(self.content)
         self.mPlayer.prepare()
         self.mPlayer.start()
@@ -79,3 +97,39 @@ class Player(object):
 
     def is_playing(self):
         return self.mPlayer.isPlaying()
+
+    def release_media_player(self):
+        if not self.mPlayer:
+            return
+        self.mPlayer.release()
+        self.mPlayer = None
+
+    def _on_audio_focus_change(self, focus_change):
+        if focus_change == AudioManager().AUDIOFOCUS_LOSS:
+            self.stop()
+        elif focus_change == AudioManager().AUDIOFOCUS_LOSS_TRANSIENT:
+            self.pause()
+        elif focus_change == AudioManager().AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
+            self.mPlayer.setVolume(0.2, 0.2)
+        elif focus_change == AudioManager().AUDIOFOCUS_GAIN:
+            self.mPlayer.setVolume(1.0, 1.0)
+            self.resume()
+
+    def user_defined_focus_change(self, focus_change):
+        if focus_change == AudioManager().AUDIOFOCUS_LOSS:
+            self.on_audio_focus_change("AUDIOFOCUS_LOSS")
+        elif focus_change == AudioManager().AUDIOFOCUS_LOSS_TRANSIENT:
+            self.on_audio_focus_change("AUDIOFOCUS_LOSS_TRANSIENT")
+        elif focus_change == AudioManager().AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
+            self.on_audio_focus_change("AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK")
+        elif focus_change == AudioManager().AUDIOFOCUS_GAIN:
+            self.on_audio_focus_change("AUDIOFOCUS_GAIN")
+
+    def request_audio_focus(self):
+        focusChangeListener = OnAudioFocusChangeListener(
+            callback=self.user_defined_focus_change or self._on_audio_focus_change)
+        am = cast_object("audioManager", activity.getSystemService(Context().AUDIO_SERVICE))
+        result = am.requestAudioFocus(focusChangeListener, AudioManager().STREAM_MUSIC, AudioManager().AUDIOFOCUS_GAIN)
+        if result == AudioManager().AUDIOFOCUS_REQUEST_GRANTED:
+            return True
+        return False


### PR DESCRIPTION
This PR will still allow kvdroid to be called by any python framework that works on android (kivy, kivymd, etc....) as long as the framework supports `pyjnius`(created by kivy community) and `android`(created by kivy community) module and also be able to work as a standalone framework of its own, being able to create native android ui and have its own mainloop runner, that holds the UI until a stop event is issued.

Task:

- [x] create a mainloop app runner that will hold the UI
- [x] implement python kvdroid version of onPause, onDestroy, onCreate, onResume event
- [x] implement python kvdroid version of Android basic widget API 