### PR TITLE
removed casting of android version from string to int

### DIFF
--- a/kvdroid/tools/__init__.py
+++ b/kvdroid/tools/__init__.py
@@ -23,8 +23,7 @@ from android.runnable import run_on_ui_thread  # NOQA
 
 def _android_version():
     version = VERSION(instantiate=True)
-    release_version = version.RELEASE
-    return int(release_version)
+    return version.RELEASE
 
 android_version = _android_version()
 


### PR DESCRIPTION
@yunus-ceyhan Due to some android version contains version numbers that looks like this `8.1.0`, I deemed it necessary to remove the casting to int because it crashes on devices with those kind of version number